### PR TITLE
Change external_id to id

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ This example shows how to use the index_documents method:
     content_source_key = '' # your content source key
     documents = [
       {
-        'external_id' => 'INscMGmhmX4',
+        'id' => 'INscMGmhmX4',
         'url' => 'http://www.youtube.com/watch?v=v1uyQZNg2vE',
         'title' => 'The Original Grumpy Cat',
         'body' => 'this is a test'
       },
       {
-        'external_id' => 'JNDFojsd02',
+        'id' => 'JNDFojsd02',
         'url' => 'http://www.youtube.com/watch?v=tsdfhk2j',
         'title' => 'Another Grumpy Cat',
         'body' => 'this is also a test'
@@ -61,10 +61,10 @@ This example shows how to use the index_documents method:
 ### Destroying Documents
 
     content_source_key = '' # your content source key
-    document_external_ids = ['INscMGmhmX4', 'JNDFojsd02']
+    document_ids = ['INscMGmhmX4', 'JNDFojsd02']
 
     begin
-      destroy_document_results = swiftype.destroy_documents(content_source_key, document_external_ids)
+      destroy_document_results = swiftype.destroy_documents(content_source_key, document_ids)
       # handle destroy document results
     rescue SwiftypeEnterprise::ClientException => e
       # handle error

--- a/lib/swiftype-enterprise/client.rb
+++ b/lib/swiftype-enterprise/client.rb
@@ -42,7 +42,7 @@ module SwiftypeEnterprise
     # For more information on indexing documents, see the {Content Source documentation}[https://app.swiftype.com/ent/docs/custom_sources].
     module ContentSourceDocuments
       REQUIRED_TOP_LEVEL_KEYS = [
-        'external_id',
+        'id',
         'url',
         'title',
         'body'

--- a/lib/swiftype-enterprise/version.rb
+++ b/lib/swiftype-enterprise/version.rb
@@ -1,3 +1,3 @@
 module SwiftypeEnterprise
-  VERSION = '2.0.0'
+  VERSION = '3.0.0'
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -12,19 +12,19 @@ describe SwiftypeEnterprise::Client do
     def check_receipt_response_format(response, options = {})
       expect(response.keys).to match_array(["document_receipts", "batch_link"])
       expect(response["document_receipts"]).to be_a_kind_of(Array)
-      expect(response["document_receipts"].first.keys).to match_array(["id", "external_id", "links", "status", "errors"])
-      expect(response["document_receipts"].first["external_id"]).to eq(options[:external_id]) if options[:external_id]
+      expect(response["document_receipts"].first.keys).to match_array(["id", "id", "links", "status", "errors"])
+      expect(response["document_receipts"].first["id"]).to eq(options[:id]) if options[:id]
       expect(response["document_receipts"].first["status"]).to eq(options[:status]) if options[:status]
       expect(response["document_receipts"].first["errors"]).to eq(options[:errors]) if options[:errors]
     end
 
     let(:content_source_key) { '59542d332139de0acacc7dd4' }
     let(:documents) do
-      [{'external_id'=>'INscMGmhmX4',
+      [{'id'=>'INscMGmhmX4',
         'url' => 'http://www.youtube.com/watch?v=v1uyQZNg2vE',
         'title' => 'The Original Grumpy Cat',
         'body' => 'this is a test'},
-       {'external_id'=>'JNDFojsd02',
+       {'id'=>'JNDFojsd02',
                'url' => 'http://www.youtube.com/watch?v=tsdfhk2j',
                'title' => 'Another Grumpy Cat',
                'body' => 'this is also a test'}]
@@ -45,7 +45,7 @@ describe SwiftypeEnterprise::Client do
           VCR.use_cassette(:document_receipts_multiple_complete) do
             client.index_documents(content_source_key, documents)
             VCR.use_cassette(:destroy_documents_success) do
-              response = client.destroy_documents(content_source_key, [documents.first['external_id']])
+              response = client.destroy_documents(content_source_key, [documents.first['id']])
               expect(response.size).to eq(1)
               expect(response.first['success']).to eq(true)
             end

--- a/spec/fixtures/vcr/async_create_or_update_document_success.yml
+++ b/spec/fixtures/vcr/async_create_or_update_document_success.yml
@@ -5,8 +5,8 @@ http_interactions:
     uri: http://localhost:3002/api/v1/ent/sources/59542d332139de0acacc7dd4/documents/bulk_create.json
     body:
       encoding: UTF-8
-      string: '[{"external_id":"INscMGmhmX4","url":"http://www.youtube.com/watch?v=v1uyQZNg2vE","title":"The
-        Original Grumpy Cat","body":"this is a test"},{"external_id":"JNDFojsd02","url":"http://www.youtube.com/watch?v=tsdfhk2j","title":"Another
+      string: '[{"id":"INscMGmhmX4","url":"http://www.youtube.com/watch?v=v1uyQZNg2vE","title":"The
+        Original Grumpy Cat","body":"this is a test"},{"id":"JNDFojsd02","url":"http://www.youtube.com/watch?v=tsdfhk2j","title":"Another
         Grumpy Cat","body":"this is also a test"}]'
     headers:
       Accept-Encoding:
@@ -47,7 +47,7 @@ http_interactions:
       - thin 1.5.0 codename Knife
     body:
       encoding: UTF-8
-      string: '[{"id":null,"external_id":"1234","errors":[]},{"id":null,"external_id":"1235","errors":[]}]'
+      string: '[{"id":null,"id":"1234","errors":[]},{"id":null,"id":"1235","errors":[]}]'
     http_version:
   recorded_at: Wed, 05 Jul 2017 17:52:09 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/destroy_documents_success.yml
+++ b/spec/fixtures/vcr/destroy_documents_success.yml
@@ -47,7 +47,7 @@ http_interactions:
       - thin 1.5.0 codename Knife
     body:
       encoding: UTF-8
-      string: '[{"external_id":"INscMGmhmX4","success":true}]'
-    http_version: 
+      string: '[{"id":"INscMGmhmX4","success":true}]'
+    http_version:
   recorded_at: Wed, 05 Jul 2017 17:52:12 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
The documents API is changing to be just 'id' instead of 'external_id'.

These changes adhere to the new requirement.

Bumped to version 3.0.0 since this is a breaking change.