### PR TITLE
Updated base endpoints and versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Create a new instance of the Swiftype Enterprise Client with your access token:
     SwiftypeEnterprise.access_token = '' # your access token
     swiftype = SwiftypeEnterprise::Client.new
 
+### Change API endpoint
+
+ ```
+swiftype = SwiftypeEnterprise::Client.new
+SwiftypeEnterprise.endpoint = 'https://your-server.example.com/api/v1'
+```
+
+
 ### Indexing Documents
 
 This example shows how to use the index_documents method:

--- a/lib/swiftype-enterprise/configuration.rb
+++ b/lib/swiftype-enterprise/configuration.rb
@@ -3,7 +3,7 @@ require 'swiftype-enterprise/version'
 
 module SwiftypeEnterprise
   module Configuration
-    DEFAULT_ENDPOINT = "https://api.swiftype.com/api/v1/"
+    DEFAULT_ENDPOINT = "http://localhost:3002/api/v1/"
     DEFAULT_USER_AGENT = "swiftype-enterprise-ruby/#{SwiftypeEnterprise::VERSION}"
 
     VALID_OPTIONS_KEYS = [

--- a/lib/swiftype-enterprise/version.rb
+++ b/lib/swiftype-enterprise/version.rb
@@ -1,3 +1,3 @@
 module SwiftypeEnterprise
-  VERSION = '3.0.0'
+  VERSION = '7.2.0-beta.2'
 end


### PR DESCRIPTION
- Changed default endpoint to localhost.
- Documented how to change endpoint.
- Updated version to match enterprise search version, 7.2.0-beta.2.