### PR TITLE
Release 3.0.0

### DIFF
--- a/lib/swiftype-enterprise/version.rb
+++ b/lib/swiftype-enterprise/version.rb
@@ -1,3 +1,3 @@
 module SwiftypeEnterprise
-  VERSION = '7.2.0-beta.2'
+  VERSION = '3.0.0'
 end


### PR DESCRIPTION
A few things to note here:

When Enterprise Search went into Beta 2, this client was updated and published as "7.2.0-beta.2". This was incorrect. They should have been published under "0.1.0-beta.1", matching the same version as Enterprise Search itself. I prematurely updated the versioning strategy to attempt to follow the stack version.

This tag version was never advertised, documentation simply pointed users to download the latest version of this client, which was 2.0.0.

Because we are not advertising these tag versions, we need to go back to the original versioning strategy. Since there are breaking changes, that means this will be version 3.0.0.