### PR TITLE
Fix gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To install the gem, execute:
 gem install elastic-enterprise-search
 ```
 
-Or place `gem 'elastic-enterprise-search', '~> 0.1.0` in your `Gemfile` and run `bundle install`.
+Or place `gem 'elastic-enterprise-search', '~> 0.2.0` in your `Gemfile` and run `bundle install`.
 
 ## Usage
 

--- a/lib/elastic-enterprise-search.rb
+++ b/lib/elastic-enterprise-search.rb
@@ -1,0 +1,1 @@
+require 'elastic/enterprise-search'

--- a/lib/elastic/enterprise-search/version.rb
+++ b/lib/elastic/enterprise-search/version.rb
@@ -1,5 +1,5 @@
 module Elastic
   module EnterpriseSearch
-    VERSION = '0.1.0'
+    VERSION = '0.2.0'
   end
 end


### PR DESCRIPTION
TL;DR: This PR allows you to *not* have to require 'elastic/enterprise-search' in order to use this client.

Rails calls `Bundler.require` on initialization.

For every gem in Gemfile, `Bundler.require` will require that
gem, by attempting to require according to the gems name.

This means that typically, gems must have a file under `lib` that
corresponds to the name of the gem.

This gem was expecting users to require with `elastic/enterprise-search`,
which did not match the gem name. This means gems had to be
explicitly required in Rails and also is a bit of an anti-pattern for
Ruby.

This fixes that by adding the correct file, so that this gem will be
auto-required by Rails and also available via
`require elastic-enterprise-search`, which remaining backwards compatible with
`require elastic/enterprise-search`.

The way I tested this locally was in a separate project with a `Gemfile` including:
```
gem "elastic-enterprise-search", path:"/Users/jasonstoltzfus/workspace/enterprise-search-ruby"
```

Then in irb, confirming that this constant was available without a `require`
```
Bundler.require
Elastic::EnterpriseSearch::Client
```

I also built the corresponding gem and confirmed that `require elastic-enterprise-search` works.