### PR TITLE
Update the path to the ca bundle

### DIFF
--- a/lib/elastic/enterprise-search/request.rb
+++ b/lib/elastic/enterprise-search/request.rb
@@ -50,7 +50,7 @@ module Elastic
             # is Charles, which uses a self-signed certificate in order to inspect https traffic. This will
             # not be part of this client's public API, this is more of a development enablement option
             http.verify_mode = ENV['st_ssl_verify_none'] == 'true' ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
-            http.ca_file = File.join(File.dirname(__FILE__), '..', 'data', 'ca-bundle.crt')
+            http.ca_file = File.realpath(File.join(File.dirname(__FILE__), '..', '..', 'data', 'ca-bundle.crt'))
             http.ssl_timeout = open_timeout
           end
 


### PR DESCRIPTION
In 5251490d, some files got moved around and the relative path to the ca bundle didn't get updated to reflect that, causing a regression with ssl-enabled endpoints.