### PR TITLE
[DOCS] Adds Release Notes

### DIFF
--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -15,3 +15,5 @@ include::enterprise-search-api.asciidoc[]
 include::app-search-api.asciidoc[]
 
 include::workplace-search-api.asciidoc[]
+
+include::release_notes/index.asciidoc[]

--- a/docs/guide/release_notes/710.asciidoc
+++ b/docs/guide/release_notes/710.asciidoc
@@ -1,0 +1,4 @@
+[[release_notes_710]]
+=== 7.10.0.beta.1 Release notes
+
+First beta release. It supports the 7.10.0 API for Elastic Enterprise Search, App Search and Workplace Search.

--- a/docs/guide/release_notes/711.asciidoc
+++ b/docs/guide/release_notes/711.asciidoc
@@ -1,0 +1,27 @@
+[[release_notes_711]]
+=== 7.11.0 Release notes
+
+First General Availability Release
+
+[discrete]
+==== General
+
+- All App Search, Workplace Search and Enterprise Search API endpoints have been implemented updated to the 7.11 specification, and have been tested and documented.
+- Docs were moved from the README file to asciidocs.
+- Some endpoints both in App Search and Workplace Search have changed to have named parameters for `body` when it makes sense.
+- Support for per request custom HTTP headers was added. See docs.
+- Support for per request http authentication was added when using OAuth. See docs.
+- Tested with Ruby 3.
+- Sends the `X-Elastic-Client-Meta` HTTP header which is used by Elastic Cloud and can be disabled with the `enable_meta_header` parameter.
+
+[discrete]
+==== App Search
+
+- Added support for signed search key in App Search.
+
+[discrete]
+==== Workplace Search
+
+- `content_source_key` was deprecated in favour of `content_source_id`.
+- Added support for OAuth.
+- With OAuth support, `search` and `create_analytics` APIs are now also available.

--- a/docs/guide/release_notes/index.asciidoc
+++ b/docs/guide/release_notes/index.asciidoc
@@ -1,0 +1,12 @@
+[[release_notes]]
+== Release Notes
+
+
+[discrete]
+=== 7.x
+
+* <<release_notes_711, 7.11.0 Release Notes>>
+* <<release_notes_710, 7.10.0.beta.1 Release Notes>>
+
+include::711.asciidoc[]
+include::710.asciidoc[]


### PR DESCRIPTION
@chriscressman Would this be ok for the client docs?

I emulated what we have in [elasticsearch-ruby](https://github.com/elastic/elasticsearch-ruby/tree/master/docs/release_notes) for release notes. This way we also keep the changelog on the docs website.