### PR TITLE
Update app-search-api.asciidoc

### DIFF
--- a/docs/guide/app-search-api.asciidoc
+++ b/docs/guide/app-search-api.asciidoc
@@ -35,7 +35,7 @@ client.create_engine(body: body)
 # Add a source engine to a meta engine:
 client.add_meta_engine_source(meta_engine_name, source_engines: ['engine1', 'engine2'])
 
-# Remove a source enginge from a meta engine:
+# Remove a source engine from a meta engine:
 client.delete_meta_engine_source(meta_engine_name, source_engines: ['engine1', 'engine2'])
 ----------------------------
 
@@ -72,7 +72,9 @@ client.put_documents(engine_name, documents: [{id: document_id, key: value}])
 ----------------------------
 # Single Search
 query = {
-  query: 'luigi'
+  body: {
+    query: 'luigi'
+  }
 }
 
 client.search(engine_name, query)


### PR DESCRIPTION
App search example had an incorrect example since search query requires a body field to be present.
It was throwing this before the proposed change:
```
`search': Required parameter 'body (query)' missing (ArgumentError)
```
This PR fixes that